### PR TITLE
Initialized property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,6 @@ fabric.properties
 
 # Editor-based Rest Client
 .idea/httpRequests
+
+# vim swap files
+.*.sw?

--- a/aiologger/handlers/base.py
+++ b/aiologger/handlers/base.py
@@ -43,6 +43,11 @@ class Handler(Filterer):
         self._loop: Optional[asyncio.AbstractEventLoop] = loop
 
     @property
+    @abc.abstractmethod
+    def initialized(self):
+        raise NotImplementedError()
+
+    @property
     def loop(self):
         if self._loop is None:
             self._loop = asyncio.get_event_loop()


### PR DESCRIPTION
Logger assumes that a property called `initialized` always exists when closing the handler:

https://github.com/b2wdigital/aiologger/blob/9f43b2dae51309565ba36ad531142237965aa7c0/aiologger/logger.py#L340

However, the existence of the property is not required by the base `Handler` abstract class. This PR maps this property in the base handler so as to help with autocomplete and to force subclasses to implement this method.