### PR TITLE
Delay creation of coroutine until after the record creation

### DIFF
--- a/aiologger/loggers/json.py
+++ b/aiologger/loggers/json.py
@@ -1,6 +1,6 @@
 import json
 from datetime import timezone
-from asyncio import AbstractEventLoop
+from asyncio import AbstractEventLoop, Task
 from typing import Dict, Iterable, Callable, Tuple, Any, Optional, Mapping
 
 from aiologger import Logger
@@ -62,7 +62,7 @@ class JsonLogger(Logger):
             formatter=formatter,
         )
 
-    async def _log(  # type: ignore
+    def _log(  # type: ignore
         self,
         level: LogLevel,
         msg: Any,
@@ -73,7 +73,7 @@ class JsonLogger(Logger):
         flatten: bool = False,
         serializer_kwargs: Dict = None,
         caller: _Caller = None,
-    ):
+    ) -> Task:
         """
         Low-level logging routine which creates a ExtendedLogRecord and
         then calls all the handlers of this logger to handle the record.
@@ -108,4 +108,4 @@ class JsonLogger(Logger):
             flatten=flatten or self.flatten,
             serializer_kwargs=serializer_kwargs or self.serializer_kwargs,
         )
-        await self.handle(record)
+        return self.loop.create_task(self.handle(record))


### PR DESCRIPTION
This should maintain API compatibility, as `await logger._log` still works.

Critically the two tests `tests.loggers.test_json_logger.JsonLoggerTests.test_log_makes_a_record_with_build_exc_info_from_exception` and `tests.test_logger.LoggerTests.test_log_makes_a_record_with_build_exc_info_from_exception` await `logger._log`