### PR TITLE
Fix bug in AsyncTimedRotatingFileHandler

### DIFF
--- a/aiologger/handlers/files.py
+++ b/aiologger/handlers/files.py
@@ -404,7 +404,7 @@ class AsyncTimedRotatingFileHandler(BaseAsyncRotatingFileHandler):
         if len(result) < self.backup_count:
             return []
         else:
-            result.sort(reverse=True)  # os.listdir order is not defined
+            result.sort()  # os.listdir order is not defined
             return result[: len(result) - self.backup_count]
 
     async def _delete_files(self, file_paths: List[str]):


### PR DESCRIPTION
Fixed bug with removing latest log files instead of oldest

## Todo
- [ ] Add a new test case that confirms the new desired behavior;