### PR TITLE
Workflow para releases oficiais

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+
+jobs:
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Install python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Install pip
+        run: pip install -U pip==20.2.3
+
+      - name: Install twine
+        run: pip install twine==3.2.0
+
+      - name: Generate Packages
+        run: python setup.py sdist
+
+      - name: Twine check
+        run: twine check dist/*
+
+      - name: Publish aiologger (${{github.ref}})
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{secrets.PYPI_TOKEN}}
+        run: twine upload dist/*


### PR DESCRIPTION
Apesar do filtro de tags estar como `'[0-9]+.[0-9]+.[0-9]+'` não consegui fazer o workflow rodar quando fiz push de uma tag de teste: `0.6.1`. =/

O arquivo estava na pasta errada. Estava em `.github/` e deveria estar em `.github/workflows`. 🤦🏼 
Tudo certo agora! 🎉 