### PR TITLE
Feature/install release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,16 @@
+categories:
+  - title: 'Mudanças incompatíveis'
+    label: 'breaking-change'
+  - title: 'Bugs Resolvidos'
+    label: 'bug'
+  - title: 'Novas Features'
+    label: 'feature'
+  - title: 'Documentação'
+    label: 'docs'
+change-template: '- #$NUMBER $TITLE (@$AUTHOR)'
+template: |
+  ## Changelog
+
+  $CHANGES
+
+  Docs: https://b2wdigital.github.io/aiologger/

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,9 +8,21 @@ categories:
   - title: 'Documentação'
     label: 'docs'
 change-template: '- #$NUMBER $TITLE (@$AUTHOR)'
+version-resolver:
+  minor:
+    labels:
+      - 'breaking-change'
+  patch:
+    labels:
+      - 'feature'
+      - 'bug'
+  default: patch
 template: |
   ## Changelog
 
   $CHANGES
 
   Docs: https://b2wdigital.github.io/aiologger/
+
+  Commits: https://github.com/b2wdigital/aiologger/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
+  Tag: https://github.com/b2wdigital/aiologger/releases/tag/$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,14 @@
+name: release-drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Instala o Release Drafter. Com ele, cada pr mergeado na master temos um Draf de uma release sendo atualizado.

A nova versão já é sugerida com base nas labels dos PRs.

- `bug` e `feature` aumenta a `patch` version.
- `breaking-change` aumenta a `minor` version.

Fazemos assim pois o aiologger ainda é experimental e não tem uma versão `1.x.y`.